### PR TITLE
Fix Null Reference Exception on stopping Quartz

### DIFF
--- a/Source/Topshelf.Quartz/SchedulejobServiceConfiguratorExtensions.cs
+++ b/Source/Topshelf.Quartz/SchedulejobServiceConfiguratorExtensions.cs
@@ -93,7 +93,8 @@ namespace Topshelf.Quartz
 				configurator.BeforeStoppingService(() =>
 						                {
 											log.Debug("[Topshelf.Quartz] Scheduler shutting down...");
-											Scheduler.Shutdown(true);
+											if(Scheduler != null)
+												Scheduler.Shutdown(true);
 											log.Info("[Topshelf.Quartz] Scheduler shut down...");
 						                });
 


### PR DESCRIPTION
When other code uses a `BeforeStartingService`
but cancels service start, this extensions
`BeforeStoppingService` is called without the
`BeforeStartingService` ever being called. In this
situation, `Scheduler` is null, and calling
`Scheduler.Shutdown()` causes a Null Reference Exception.

```c#
// Other TopShelf startup code.
s.BeforeStartingService(hsc =>
  {
	if (CanStartPreconditionsMet())
	{
	    return;
	}

    Log.Fatal("Some message.");

    hsc.CancelStart();
});
```