### PR TITLE
Added ability to replace a job when scheduling through Quartz

### DIFF
--- a/Source/Topshelf.Quartz/ScheduleJobHostConfiguratorExtensions.cs
+++ b/Source/Topshelf.Quartz/ScheduleJobHostConfiguratorExtensions.cs
@@ -20,10 +20,10 @@ namespace Topshelf.Quartz
 		}
 
 
-		public static HostConfigurator ScheduleQuartzJobAsService(this HostConfigurator configurator, Action<QuartzConfigurator> jobConfigurator)
+		public static HostConfigurator ScheduleQuartzJobAsService(this HostConfigurator configurator, Action<QuartzConfigurator> jobConfigurator, bool replaceJob = false)
 		{
 			configurator.Service<NullService>(s => s
-													.ScheduleQuartzJob(jobConfigurator)									   
+													.ScheduleQuartzJob(jobConfigurator, replaceJob)									   
 				                                    .WhenStarted(p => p.Start())
 				                                    .WhenStopped(p => p.Stop())
 													.ConstructUsing(settings => new NullService())

--- a/Source/Topshelf.Quartz/SchedulejobServiceConfiguratorExtensions.cs
+++ b/Source/Topshelf.Quartz/SchedulejobServiceConfiguratorExtensions.cs
@@ -50,13 +50,13 @@ namespace Topshelf.Quartz
 			return UsingQuartzJobFactory(configurator, () => new TJobFactory());
 		}
 
-		public static ServiceConfigurator<T> ScheduleQuartzJob<T>(this ServiceConfigurator<T> configurator, Action<QuartzConfigurator> jobConfigurator) where T : class
+		public static ServiceConfigurator<T> ScheduleQuartzJob<T>(this ServiceConfigurator<T> configurator, Action<QuartzConfigurator> jobConfigurator, bool replaceJob = false) where T : class
 		{
-			ConfigureJob<T>(configurator, jobConfigurator);
+			ConfigureJob<T>(configurator, jobConfigurator, replaceJob);
 			return configurator;
 		}
 
-		private static void ConfigureJob<T>(ServiceConfigurator<T> configurator, Action<QuartzConfigurator> jobConfigurator) where T : class
+		private static void ConfigureJob<T>(ServiceConfigurator<T> configurator, Action<QuartzConfigurator> jobConfigurator, bool replaceJob = false) where T : class
 		{
 			var log = HostLogger.Get(typeof(ScheduleJobServiceConfiguratorExtensions));
 
@@ -78,7 +78,7 @@ namespace Topshelf.Quartz
 															if (Scheduler != null && jobDetail != null && jobTriggers.Any())
 															{
 																var triggersForJob = new HashSet<ITrigger>(jobTriggers);
-																Scheduler.ScheduleJob(jobDetail, triggersForJob, false);
+																Scheduler.ScheduleJob(jobDetail, triggersForJob, replaceJob);
 																log.Info(string.Format("[Topshelf.Quartz] Scheduled Job: {0}", jobDetail.Key));
 					
 																foreach(var trigger in triggersForJob)


### PR DESCRIPTION
We've been using Topshelf to host our quartz services and have recently been asked to make sure the services work in a load balanced environment.  To do this we are using the built in functionality within Quartz but whenever we schedule a job via Topshelf it tries to create a new job which fails on the second machine as it already exists in the quartz tables.  To resolve this issue I've added an optional replaceJob parameter which will force Quartz to override the job if it has already been created by another node.